### PR TITLE
Added Laravel artisan commands assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.x
+
+### Added
+
+- Trait `LaravelCommandsAssertionsTrait`
+
 ## v1.1.6
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ class MyBootstrap extends \AvtoDev\DevTools\Tests\Bootstrap\AbstractTestsBootstr
 `InstancesAccessorsTrait` | Методы доступа к protected\private методам\свойствам у классов (с помощью рефлексии)
 `LaravelEventsAssertionsTrait` | Методы тестирования событий (events) и их слушателей (listeners)
 `LaravelLogFilesAssertsTrait` | Методы тестирования лог-файлов Laravel приложения
+`LaravelCommandsAssertionsTrait` | Методы тестирования Laravel artisan комманд.
 
 -----
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="true"
-         syntaxCheck="true">
+         stopOnFailure="true">
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests</directory>

--- a/src/Tests/PHPUnit/AbstractLaravelTestCase.php
+++ b/src/Tests/PHPUnit/AbstractLaravelTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit;
 

--- a/src/Tests/PHPUnit/AbstractLaravelTestCase.php
+++ b/src/Tests/PHPUnit/AbstractLaravelTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit;
 
@@ -13,7 +13,8 @@ abstract class AbstractLaravelTestCase extends TestCase
         Traits\InstancesAccessorsTrait,
         Traits\CreatesApplicationTrait,
         Traits\LaravelLogFilesAssertsTrait,
-        Traits\LaravelEventsAssertionsTrait;
+        Traits\LaravelEventsAssertionsTrait,
+        Traits\LaravelCommandsAssertionsTrait;
 
     /**
      * Make some before application bootstrapped (call `$app->useStoragePath(...)`, `$app->loadEnvironmentFrom(...)`,

--- a/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
@@ -3,6 +3,7 @@
 namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
 use Illuminate\Console\Command;
+use PHPUnit\Framework\Exception;
 use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
@@ -103,7 +104,7 @@ trait LaravelCommandsAssertionsTrait
      * @param string         $shortcut Shortcut name
      * @param string         $option   Option name
      *
-     * @throws \ReflectionException
+     * @throws Exception
      * @throws InvalidArgumentException
      */
     public function assertArtisanCommandShortcutBelongToOption(string $shortcut, string $option, $command)

--- a/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
@@ -2,10 +2,10 @@
 
 namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
-use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 
 /**
  * Trait LaravelCommandsAssertionsTrait.
@@ -50,7 +50,6 @@ trait LaravelCommandsAssertionsTrait
      *
      * @param string|Command $command Command name|class_name|instance that must be checked
      * @param string         $option  Option name
-     *
      *
      * @throws InvalidArgumentException
      */
@@ -161,7 +160,7 @@ trait LaravelCommandsAssertionsTrait
     }
 
     /**
-     * Build command
+     * Build command.
      *
      * @param string|Command $command Command name|class_name|instance that must be checked
      *

--- a/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTrait.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+
+/**
+ * Trait LaravelCommandsAssertionsTrait.
+ *
+ * @mixin AbstractLaravelTestCase
+ */
+trait LaravelCommandsAssertionsTrait
+{
+    /**
+     * Assert that command registered in artisan.
+     *
+     * @param string|Command $command Command name|class_name|instance that must be checked
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandExists($command)
+    {
+        if (\is_object($command)) {
+            $command = get_class($command);
+        }
+
+        // Array of registered commands. ['command_name'=>instance]
+        $all_commands = $this->app->make(ConsoleKernelContract::class)->all();
+
+        $message = "Command {$command} does not exists";
+
+        $command_exists = \array_key_exists($command, $all_commands);
+
+        if (! $command_exists) {
+            foreach ($all_commands as $command_instance) {
+                if ($command_exists = $command_instance instanceof $command) {
+                    break;
+                }
+            }
+        }
+
+        static::assertTrue($command_exists, $message);
+    }
+
+    /**
+     * Asserts that command has specific option.
+     *
+     * @param string|Command $command Command name|class_name|instance that must be checked
+     * @param string         $option  Option name
+     *
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandHasOption(string $option, $command)
+    {
+        $command = $this->buildCommand($command);
+
+        $message = sprintf('Command %s has no option "%s"', get_class($command), $option);
+
+        static::assertTrue($command->getDefinition()->hasOption($option), $message);
+    }
+
+    /**
+     * Asserts that command has specific argument.
+     *
+     * @param string|Command $command  Command name|class_name|instance that must be checked
+     * @param string         $argument Argument name
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandHasArgument(string $argument, $command)
+    {
+        $command = $this->buildCommand($command);
+
+        $message = sprintf('Command %s has no argument "%s"', get_class($command), $argument);
+
+        static::assertTrue($command->getDefinition()->hasArgument($argument), $message);
+    }
+
+    /**
+     * Assert that command has specific option shortcut.
+     *
+     * @param string|Command $command  Command name|class_name|instance that must be checked
+     * @param string         $shortcut Shortcut name
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandHasOptionShortcut(string $shortcut, $command)
+    {
+        $command = $this->buildCommand($command);
+
+        $message = sprintf('Command %s has no shortcut "%s"', get_class($command), $shortcut);
+
+        static::assertTrue($command->getDefinition()->hasShortcut($shortcut), $message);
+    }
+
+    /**
+     * Assert that command shortcut belongs to specific option.
+     *
+     * @param string|Command $command  Command name|class_name|instance that must be checked
+     * @param string         $shortcut Shortcut name
+     * @param string         $option   Option name
+     *
+     * @throws \ReflectionException
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandShortcutBelongToOption(string $shortcut, string $option, $command)
+    {
+        $this->assertArtisanCommandHasOptionShortcut($shortcut, $command);
+
+        $command = $this->buildCommand($command);
+
+        $message = sprintf(
+            'Shortcut "%s" in command "%s" does not belong to option "%s" ',
+            $shortcut,
+            get_class($command),
+            $option
+        );
+
+        static::assertEquals(
+            $option,
+            $this->getObjectAttribute($command->getDefinition(), 'shortcuts')[$shortcut] ?? '',
+            $message
+        );
+    }
+
+    /**
+     * Assert that artisan command has description.
+     *
+     * @param string|Command $command Command name|class_name|instance that must be checked
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandDescriptionNotEmpty($command)
+    {
+        $command = $this->buildCommand($command);
+
+        $message = sprintf('Command "%s" has empty description', get_class($command));
+
+        static::assertNotEmpty($command->getDescription(), $message);
+    }
+
+    /**
+     * Assert that artisan command has description.
+     *
+     * @param string|Command $command Command name|class_name|instance that must be checked
+     * @param string         $pattern Regular expression     *
+     *
+     * @throws InvalidArgumentException
+     */
+    public function assertArtisanCommandDescriptionRegExp(string $pattern, $command)
+    {
+        $command = $this->buildCommand($command);
+
+        $message = sprintf('Description of command "%s" does not match regexp "%s"', get_class($command), $pattern);
+
+        static::assertRegExp($pattern, $command->getDescription(), $message);
+    }
+
+    /**
+     * Build command
+     *
+     * @param string|Command $command Command name|class_name|instance that must be checked
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return Command
+     */
+    protected function buildCommand($command): Command
+    {
+        /** @var ConsoleKernelContract $artisan */
+        $artisan = $this->app->make(ConsoleKernelContract::class);
+
+        if (! \is_object($command)) {
+            if (\array_key_exists($command, $artisan->all())) {
+                $command = $artisan->all()[$command];
+            } elseif (\class_exists($command)) {
+                $command = $this->app->make($command);
+                static::assertInstanceOf(Command::class, $command);
+            }
+        }
+
+        return $command;
+    }
+}

--- a/tests/Tests/PHPUnit/AbstractTestCasesTest.php
+++ b/tests/Tests/PHPUnit/AbstractTestCasesTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\AvtoDev\DevTools\Tests\PHPUnit;
 
-use Tests\AvtoDev\DevTools\AbstractTestCase;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
+use Tests\AvtoDev\DevTools\AbstractTestCase;
 
 class AbstractTestCasesTest extends AbstractTestCase
 {
@@ -19,7 +20,8 @@ class AbstractTestCasesTest extends AbstractTestCase
      */
     public function testAbstractTestCase()
     {
-        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractTestCase {
+        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractTestCase
+        {
         };
 
         $this->assertInstanceOf(\PHPUnit\Framework\TestCase::class, $instance);
@@ -36,7 +38,8 @@ class AbstractTestCasesTest extends AbstractTestCase
      */
     public function testAbstractLaravelTestCase()
     {
-        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase {
+        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase
+        {
             use CreatesApplicationTrait;
         };
 
@@ -49,6 +52,7 @@ class AbstractTestCasesTest extends AbstractTestCase
             CreatesApplicationTrait::class,
             LaravelEventsAssertionsTrait::class,
             LaravelLogFilesAssertsTrait::class,
+            LaravelCommandsAssertionsTrait::class,
         ]);
     }
 }

--- a/tests/Tests/PHPUnit/AbstractTestCasesTest.php
+++ b/tests/Tests/PHPUnit/AbstractTestCasesTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\AvtoDev\DevTools\Tests\PHPUnit;
 
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
+use Tests\AvtoDev\DevTools\AbstractTestCase;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
-use Tests\AvtoDev\DevTools\AbstractTestCase;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
 
 class AbstractTestCasesTest extends AbstractTestCase
 {
@@ -20,8 +20,7 @@ class AbstractTestCasesTest extends AbstractTestCase
      */
     public function testAbstractTestCase()
     {
-        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractTestCase
-        {
+        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractTestCase {
         };
 
         $this->assertInstanceOf(\PHPUnit\Framework\TestCase::class, $instance);
@@ -38,8 +37,7 @@ class AbstractTestCasesTest extends AbstractTestCase
      */
     public function testAbstractLaravelTestCase()
     {
-        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase
-        {
+        $instance = new class extends \AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase {
             use CreatesApplicationTrait;
         };
 

--- a/tests/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTraitTest.php
@@ -2,16 +2,16 @@
 
 namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
-use Illuminate\Console\Application as ArtisanApplication;
 use Illuminate\Foundation\Application;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
+use Illuminate\Console\Application as ArtisanApplication;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
 use Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs\SignatureCommand;
 use Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs\StructureCommand;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
 
 /**
  * Class LaravelCommandsAssertionsTraitTest.
@@ -47,24 +47,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
     }
 
     /**
-     * Make some before application bootstrapped (call `$app->useStoragePath(...)`, `$app->loadEnvironmentFrom(...)`,
-     * etc).
-     *
-     * @see \AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait::createApplication
-     *
-     * @return void
-     */
-    protected function beforeApplicationBootstrapped(Application $app)
-    {
-        ArtisanApplication::starting(function (ArtisanApplication $app) {
-            $app->resolveCommands([
-                SignatureCommand::class,
-                StructureCommand::class,
-            ]);
-        });
-    }
-
-    /**
      * Check assertArtisanCommandExists.
      *
      * @throws InvalidArgumentException
@@ -72,7 +54,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
      */
     public function testAssertArtisanCommandExists()
     {
-
         $this->makeAssertTest(
             'assertArtisanCommandExists',
             [
@@ -130,7 +111,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
      */
     public function testAssertArtisanCommandHasArgument()
     {
-
         $this->makeAssertTest(
             'assertArtisanCommandHasArgument',
             [
@@ -164,7 +144,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
      */
     public function testAssertArtisanCommandHasOptionShortcut()
     {
-
         $this->makeAssertTest(
             'assertArtisanCommandHasOptionShortcut',
             [
@@ -198,7 +177,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
      */
     public function testAssertArtisanCommandShortcutBelongToOption()
     {
-
         $this->makeAssertTest(
             'assertArtisanCommandShortcutBelongToOption',
             [
@@ -299,6 +277,24 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
     }
 
     /**
+     * Make some before application bootstrapped (call `$app->useStoragePath(...)`, `$app->loadEnvironmentFrom(...)`,
+     * etc).
+     *
+     * @see \AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait::createApplication
+     *
+     * @return void
+     */
+    protected function beforeApplicationBootstrapped(Application $app)
+    {
+        ArtisanApplication::starting(function (ArtisanApplication $app) {
+            $app->resolveCommands([
+                SignatureCommand::class,
+                StructureCommand::class,
+            ]);
+        });
+    }
+
+    /**
      * @param string $method_name
      * @param array  $valid
      * @param array  $invalid
@@ -311,7 +307,6 @@ class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\
      */
     protected function makeAssertTest(string $method_name, array $valid, array $invalid, ...$args)
     {
-
         foreach ($valid as $valid_assert) {
             $this->{$method_name}($valid_assert, ...$args);
         }

--- a/tests/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/LaravelCommandsAssertionsTraitTest.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait;
+use Illuminate\Console\Application as ArtisanApplication;
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs\SignatureCommand;
+use Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs\StructureCommand;
+
+/**
+ * Class LaravelCommandsAssertionsTraitTest.
+ *
+ * @coversDefaultClass \AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelCommandsAssertionsTrait
+ */
+class LaravelCommandsAssertionsTraitTest extends \Illuminate\Foundation\Testing\TestCase
+{
+    use CreatesApplicationTrait, InstancesAccessorsTrait, LaravelCommandsAssertionsTrait;
+
+    /**
+     * Signature configured command.
+     *
+     * @var SignatureCommand
+     */
+    protected $signature_command;
+
+    /**
+     * Structure configured command.
+     *
+     * @var SignatureCommand
+     */
+    protected $structure_command;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->signature_command = resolve(SignatureCommand::class);
+        $this->structure_command = resolve(StructureCommand::class);
+    }
+
+    /**
+     * Make some before application bootstrapped (call `$app->useStoragePath(...)`, `$app->loadEnvironmentFrom(...)`,
+     * etc).
+     *
+     * @see \AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait::createApplication
+     *
+     * @return void
+     */
+    protected function beforeApplicationBootstrapped(Application $app)
+    {
+        ArtisanApplication::starting(function (ArtisanApplication $app) {
+            $app->resolveCommands([
+                SignatureCommand::class,
+                StructureCommand::class,
+            ]);
+        });
+    }
+
+    /**
+     * Check assertArtisanCommandExists.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandExists
+     */
+    public function testAssertArtisanCommandExists()
+    {
+
+        $this->makeAssertTest(
+            'assertArtisanCommandExists',
+            [
+                SignatureCommand::class,
+                'test:signature',
+                StructureCommand::class,
+                'test:structure',
+                $this->signature_command,
+                $this->structure_command,
+            ],
+            [
+                'not_found_name',
+            ]
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandHasOption.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandHasOption
+     */
+    public function testAssertArtisanCommandHasOption()
+    {
+        $this->makeAssertTest(
+            'assertArtisanCommandHasOption',
+            [
+                'option',
+            ],
+
+            [
+                'not_found_option',
+            ],
+            $this->signature_command
+        );
+
+        $this->makeAssertTest(
+            'assertArtisanCommandHasOption',
+            [
+                'option',
+            ],
+
+            [
+                'not_found_option',
+            ],
+            $this->structure_command
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandHasArgument.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandHasArgument
+     */
+    public function testAssertArtisanCommandHasArgument()
+    {
+
+        $this->makeAssertTest(
+            'assertArtisanCommandHasArgument',
+            [
+                'argument',
+            ],
+
+            [
+                'not_found_argument',
+            ],
+            $this->signature_command
+        );
+
+        $this->makeAssertTest(
+            'assertArtisanCommandHasArgument',
+            [
+                'argument',
+            ],
+
+            [
+                'not_found_argument',
+            ],
+            $this->structure_command
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandHasOptionShortcut.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandHasOptionShortcut
+     */
+    public function testAssertArtisanCommandHasOptionShortcut()
+    {
+
+        $this->makeAssertTest(
+            'assertArtisanCommandHasOptionShortcut',
+            [
+                'O',
+            ],
+
+            [
+                'not_found_shortcut',
+            ],
+            $this->signature_command
+        );
+
+        $this->makeAssertTest(
+            'assertArtisanCommandHasOptionShortcut',
+            [
+                'O',
+            ],
+
+            [
+                'not_found_shortcut',
+            ],
+            $this->structure_command
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandShortcutBelongToOption.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandShortcutBelongToOption
+     */
+    public function testAssertArtisanCommandShortcutBelongToOption()
+    {
+
+        $this->makeAssertTest(
+            'assertArtisanCommandShortcutBelongToOption',
+            [
+                'O',
+            ],
+
+            [
+                'not_found_shortcut',
+            ],
+            'option',
+            $this->signature_command
+        );
+
+        $this->makeAssertTest(
+            'assertArtisanCommandShortcutBelongToOption',
+            [
+                'O',
+            ],
+
+            [
+                'not_found_shortcut',
+            ],
+            'option',
+            $this->structure_command
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandDescriptionNotEmpty.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandDescriptionNotEmpty
+     */
+    public function testAssertArtisanCommandDescriptionNotEmpty()
+    {
+        $this->makeAssertTest(
+            'assertArtisanCommandDescriptionNotEmpty',
+            [
+                $this->structure_command,
+            ],
+
+            [
+                $this->signature_command,
+            ]
+        );
+    }
+
+    /**
+     * Check assertArtisanCommandDescriptionRegExp.
+     *
+     * @throws InvalidArgumentException
+     * @covers ::assertArtisanCommandDescriptionRegExp
+     */
+    public function testAssertArtisanCommandDescriptionRegExp()
+    {
+        $this->makeAssertTest(
+            'assertArtisanCommandDescriptionRegExp',
+            [
+                '/.*word.*/',
+            ],
+
+            [
+                '/No regexp/',
+            ],
+            $this->structure_command
+        );
+    }
+
+    /**
+     * Check buildCommand.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @covers ::buildCommand
+     */
+    public function testBuildCommand()
+    {
+        $commands = [
+            'test:signature' => [
+                $this->signature_command,
+                'test:signature',
+                SignatureCommand::class,
+            ],
+            'test:structure' => [
+                $this->structure_command,
+                'test:structure',
+                StructureCommand::class,
+            ],
+        ];
+        foreach ($commands as $command_name => $command_aliases) {
+            foreach ($command_aliases as $alias) {
+                $this->assertEquals(
+                    $command_name,
+                    $this->buildCommand($alias)->getName()
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $method_name
+     * @param array  $valid
+     * @param array  $invalid
+     * @param mixed  ...$args
+     *
+     * @throws ExpectationFailedException
+     * @throws InvalidArgumentException
+     *
+     * @return void
+     */
+    protected function makeAssertTest(string $method_name, array $valid, array $invalid, ...$args)
+    {
+
+        foreach ($valid as $valid_assert) {
+            $this->{$method_name}($valid_assert, ...$args);
+        }
+
+        foreach ($invalid as $invalid_assert) {
+            $caught = false;
+
+            try {
+                $this->{$method_name}($invalid_assert, ...$args);
+            } catch (ExpectationFailedException $e) {
+                $caught = true;
+            } catch (AssertionFailedError $e) {
+                $caught = true;
+            }
+
+            $this->assertTrue($caught, 'Passed invalid value: ' . var_export($invalid_assert, true));
+        }
+    }
+}

--- a/tests/Tests/PHPUnit/Traits/Stubs/SignatureCommand.php
+++ b/tests/Tests/PHPUnit/Traits/Stubs/SignatureCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs;
+
+use Illuminate\Console\Command;
+
+class SignatureCommand extends Command
+{
+    protected $signature = 'test:signature
+    {argument}
+    {--O|option}
+    {--second_option}';
+}

--- a/tests/Tests/PHPUnit/Traits/Stubs/StructureCommand.php
+++ b/tests/Tests/PHPUnit/Traits/Stubs/StructureCommand.php
@@ -3,8 +3,8 @@
 namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 
 class StructureCommand extends Command
 {

--- a/tests/Tests/PHPUnit/Traits/Stubs/StructureCommand.php
+++ b/tests/Tests/PHPUnit/Traits/Stubs/StructureCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits\Stubs;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class StructureCommand extends Command
+{
+    protected $name        = 'test:structure';
+
+    protected $description = 'Three words description';
+
+    protected function getOptions()
+    {
+        return [
+            ['option', 'O', InputOption::VALUE_OPTIONAL],
+            ['second_option', null, InputOption::VALUE_OPTIONAL],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['argument', InputArgument::OPTIONAL],
+        ];
+    }
+}

--- a/tests/Tests/PHPUnit/Traits/logs/laravel.log
+++ b/tests/Tests/PHPUnit/Traits/logs/laravel.log
@@ -1,5 +1,0 @@
-[2018-01-01 00:00:00] testing.INFO: Some info log message 1
-[2018-01-01 00:00:00] testing.INFO: Some info log message 2
-[2018-01-01 00:00:00] testing.INFO: Some info log message 3
-[2018-01-01 00:00:00] testing.INFO: Some info log message 4
-[2018-01-01 00:00:00] testing.INFO: Some info log message 5


### PR DESCRIPTION
Добавлены ассерты для работы с артизан-коммандами:

- assertArtisanCommandExists
- assertArtisanCommandHasOption
- assertArtisanCommandHasArgument
- assertArtisanCommandHasOptionShortcut
- assertArtisanCommandShortcutBelongToOption
- assertArtisanCommandDescriptionNotEmpty
- assertArtisanCommandDescriptionRegExp
