### PR TITLE
v1.2.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,7 +11,7 @@ checks:
 
 build_failure_conditions:
   - 'elements.rating(<= D).exists'                                # No classes/methods with a rating of D or worse
-  - 'project.metric_change("scrutinizer.test_coverage", < -0.05)' # Coverage decreased from prev. inspection > 5%
+  - 'project.metric_change("scrutinizer.test_coverage", < -0.15)' # Coverage decreased from prev. inspection > 15%
 
 build:
   environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.2.0
+
+### Added
+
+- **Laravel**: Event listener for a logging database queries
+- **Laravel**: Service provider that register listener for a logging database queries
+- **Laravel**: Trait `WithDatabaseQueriesLogging` (use this trait in your tests classes for enabling all database queries logging)
+
+### Changed
+
+- Class `AbstractLaravelTestCase` now supports `WithDatabaseQueriesLogging` trait in test classes
+
 ## v1.1.7
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Для установки данного пакета выполните в терминале следующую команду:
 
 ```shell
-$ composer require --dev avto-dev/dev-tools "^1.1.5"
+$ composer require --dev avto-dev/dev-tools "^1.2"
 ```
 
 > Для этого необходим установленный `composer`. Для его установки перейдите по [данной ссылке][getcomposer].
@@ -28,6 +28,14 @@ $ composer require --dev avto-dev/dev-tools "^1.1.5"
 ## Использование
 
 Данный пакет позволяет легко интегрировать в ваше приложение вспомогательные инструменты, позволяющие более эффективно вести разработку. Разделить их можно на следующие группы:
+
+## Вспомогательные сервисы для Laravel
+
+Для Laravel-приложений вы можете подключать следующие сервис-провайдеры:
+
+Сервис-провайдер | Его назначение
+---------------- | --------------
+[DatabaseQueriesLogger](./src/Laravel/DatabaseQueriesLogger/ServiceProvider.php) | Производит запись всех обращений к базе данных в лог-файл приложения
 
 ## Unit-тестирование приложения
 
@@ -112,7 +120,8 @@ class MyBootstrap extends \AvtoDev\DevTools\Tests\Bootstrap\AbstractTestsBootstr
 `InstancesAccessorsTrait` | Методы доступа к protected\private методам\свойствам у классов (с помощью рефлексии)
 `LaravelEventsAssertionsTrait` | Методы тестирования событий (events) и их слушателей (listeners)
 `LaravelLogFilesAssertsTrait` | Методы тестирования лог-файлов Laravel приложения
-`LaravelCommandsAssertionsTrait` | Методы тестирования Laravel artisan комманд.
+`LaravelCommandsAssertionsTrait` | Методы тестирования Laravel artisan комманд
+`WithDatabaseQueriesLogging` | Подключая данный трейт в класс теста - все запросы к БД будут записываться в log-файл (класс теста должен наследоваться при этом от `AbstractLaravelTestCase`) 
 
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "php": ">=7.0 <7.3"
     },
     "require-dev": {
+        "ext-pdo_sqlite": "*",
+        "ext-sqlite3": "*",
         "laravel/laravel": ">=5.5 <5.7.0",
         "laravel/framework": ">=5.5 <5.7.0",
         "phpunit/phpunit": "^6.5 || ~7.0",

--- a/src/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListener.php
+++ b/src/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListener.php
@@ -1,13 +1,13 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
 
 use DateTime;
 use Exception;
-use Illuminate\Database\Events\QueryExecuted;
 use Psr\Log\LoggerInterface;
+use Illuminate\Database\Events\QueryExecuted;
 
 class QueryExecutedEventsListener
 {
@@ -39,7 +39,7 @@ class QueryExecutedEventsListener
     /**
      * Handle the event.
      *
-     * @param  QueryExecuted $event
+     * @param QueryExecuted $event
      *
      * @return void
      */

--- a/src/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListener.php
+++ b/src/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListener.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
+
+use DateTime;
+use Exception;
+use Illuminate\Database\Events\QueryExecuted;
+use Psr\Log\LoggerInterface;
+
+class QueryExecutedEventsListener
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Service constructor.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get logging level.
+     *
+     * @return string
+     */
+    public function loggingLevel(): string
+    {
+        return (string) env('DATABASE_QUERIES_LOGGING_LEVEL', 'debug');
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  QueryExecuted $event
+     *
+     * @return void
+     */
+    public function handle(QueryExecuted $event)
+    {
+        try {
+            $bindings   = (array) $event->bindings;
+            $duration   = $event->time;
+            $connection = $event->connection->getName();
+            $data       = \compact('bindings', 'duration', 'connection');
+
+            // Format binding data
+            foreach ($bindings as $i => $binding) {
+                if ($binding instanceof DateTime) {
+                    $bindings[$i] = $binding->format('Y-m-d H:i:s');
+                } else {
+                    if (\is_string($binding)) {
+                        $bindings[$i] = "'$binding'";
+                    }
+                }
+            }
+
+            // Insert bindings into query
+            $query_string = \str_replace(['%', '?'], ['%%', '%s'], $event->sql);
+            $query_string = \vsprintf($query_string, $bindings);
+
+            $this->logger->log($this->loggingLevel(), "Database query [$query_string]", $data);
+        } catch (Exception $e) {
+            $this->logger->error("Cannot log database query: {$e->getMessage()}", ['exception' => $e]);
+        }
+    }
+}

--- a/src/Laravel/DatabaseQueriesLogger/ServiceProvider.php
+++ b/src/Laravel/DatabaseQueriesLogger/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
 

--- a/src/Laravel/DatabaseQueriesLogger/ServiceProvider.php
+++ b/src/Laravel/DatabaseQueriesLogger/ServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
+
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+
+class ServiceProvider extends IlluminateServiceProvider
+{
+    /**
+     * Register service and listener.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->make('events')->listen(QueryExecuted::class, QueryExecutedEventsListener::class);
+    }
+}

--- a/src/Tests/PHPUnit/AbstractLaravelTestCase.php
+++ b/src/Tests/PHPUnit/AbstractLaravelTestCase.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit;
 
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseQueriesLogging;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseQueriesLogging;
 
 abstract class AbstractLaravelTestCase extends TestCase
 {

--- a/src/Tests/PHPUnit/AbstractLaravelTestCase.php
+++ b/src/Tests/PHPUnit/AbstractLaravelTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit;
 
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseQueriesLogging;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase;
 
@@ -15,6 +16,20 @@ abstract class AbstractLaravelTestCase extends TestCase
         Traits\LaravelLogFilesAssertsTrait,
         Traits\LaravelEventsAssertionsTrait,
         Traits\LaravelCommandsAssertionsTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUpTraits()
+    {
+        $uses = parent::setUpTraits();
+
+        if (isset($uses[WithDatabaseQueriesLogging::class])) {
+            $this->enableDatabaseQueriesLogging();
+        }
+
+        return $uses;
+    }
 
     /**
      * Make some before application bootstrapped (call `$app->useStoragePath(...)`, `$app->loadEnvironmentFrom(...)`,

--- a/src/Tests/PHPUnit/Traits/WithDatabaseQueriesLogging.php
+++ b/src/Tests/PHPUnit/Traits/WithDatabaseQueriesLogging.php
@@ -1,12 +1,12 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
-use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
-use Illuminate\Database\Events\QueryExecuted;
 use Psr\Log\LoggerInterface;
+use Illuminate\Database\Events\QueryExecuted;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
 
 trait WithDatabaseQueriesLogging
 {

--- a/src/Tests/PHPUnit/Traits/WithDatabaseQueriesLogging.php
+++ b/src/Tests/PHPUnit/Traits/WithDatabaseQueriesLogging.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
+use Illuminate\Database\Events\QueryExecuted;
+use Psr\Log\LoggerInterface;
+
+trait WithDatabaseQueriesLogging
+{
+    /**
+     * Database queries logger factory.
+     *
+     * @return LoggerInterface
+     */
+    public function databaseQueriesLoggerFactory(): LoggerInterface
+    {
+        return $this->app->make(LoggerInterface::class);
+    }
+
+    /**
+     * Enable database queries logging for this test class.
+     *
+     * @throws \Exception
+     */
+    public function enableDatabaseQueriesLogging()
+    {
+        $this->afterApplicationCreated(function () {
+            $this->app->make('events')->listen(QueryExecuted::class, function (QueryExecuted $event) {
+                (new QueryExecutedEventsListener($this->databaseQueriesLoggerFactory()))->handle($event);
+            });
+        });
+    }
+}

--- a/tests/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListenerTest.php
+++ b/tests/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
+
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Str;
+use Psr\Log\LoggerInterface;
+
+class QueryExecutedEventsListenerTest extends \Illuminate\Foundation\Testing\TestCase
+{
+    use CreatesApplicationTrait,
+        LaravelLogFilesAssertsTrait;
+
+    /**
+     * @var QueryExecutedEventsListener
+     */
+    protected $instance;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->instance = new QueryExecutedEventsListener($this->app->make(LoggerInterface::class));
+
+        $this->clearLaravelLogs();
+    }
+
+    /**
+     * Test log level getter.
+     *
+     * @return void
+     */
+    public function testLoggingLevel()
+    {
+        $this->assertEquals('debug', $this->instance->loggingLevel());
+
+        \putenv('DATABASE_QUERIES_LOGGING_LEVEL=warning');
+        $this->assertEquals('warning', $this->instance->loggingLevel());
+
+        // Unset back
+        \putenv('DATABASE_QUERIES_LOGGING_LEVEL');
+    }
+
+    /**
+     * Test handel method.
+     *
+     * @return void
+     */
+    public function testHandle()
+    {
+        $event = new QueryExecuted(
+            $sql = 'select * from users_' . Str::random(),
+            [$a = 'foo ' . Str::random() => $b = 'bar' . Str::random()],
+            time(),
+            $this->app->make('db')->connection()
+        );
+
+        $this->instance->handle($event);
+
+        $this->assertLogFileContains("Database query [$sql]");
+        $this->assertLogFileContains($a);
+        $this->assertLogFileContains($b);
+    }
+
+    /**
+     * Test handel method with passing datatine.
+     *
+     * @return void
+     */
+    public function testHandleWithDataTime()
+    {
+        $event = new QueryExecuted(
+            $sql = 'select * from users_' . Str::random(),
+            [$a = 'foo ' . Str::random() => $b = 'bar' . Str::random(), $datetime = new \DateTime('now')],
+            time(),
+            $this->app->make('db')->connection()
+        );
+
+        $this->instance->handle($event);
+
+        $this->assertLogFileContains("Database query [$sql]");
+        $this->assertLogFileContains($datetime->format('Y-m-d H:i:s'));
+        $this->assertLogFileContains($a);
+        $this->assertLogFileContains($b);
+    }
+}

--- a/tests/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListenerTest.php
+++ b/tests/Laravel/DatabaseQueriesLogger/QueryExecutedEventsListenerTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
 
-use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
-use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
+use Illuminate\Database\Events\QueryExecuted;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelLogFilesAssertsTrait;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
 
 class QueryExecutedEventsListenerTest extends \Illuminate\Foundation\Testing\TestCase
 {

--- a/tests/Laravel/DatabaseQueriesLogger/ServiceProviderTest.php
+++ b/tests/Laravel/DatabaseQueriesLogger/ServiceProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
+
+use Illuminate\Database\Events\QueryExecuted;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\ServiceProvider;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
+use Illuminate\Contracts\Foundation\Application;
+
+class ServiceProviderTest extends \Illuminate\Foundation\Testing\TestCase
+{
+    use CreatesApplicationTrait,
+        LaravelEventsAssertionsTrait;
+
+    /**
+     * @return void
+     */
+    protected function afterApplicationBootstrapped(Application $app)
+    {
+        $app->register(ServiceProvider::class);
+    }
+
+    /**
+     * Test event listener subscribed.
+     *
+     * @return void
+     */
+    public function testListenerRegistered()
+    {
+        $this->assertEventHasListener(QueryExecuted::class, QueryExecutedEventsListener::class);
+    }
+}

--- a/tests/Laravel/DatabaseQueriesLogger/ServiceProviderTest.php
+++ b/tests/Laravel/DatabaseQueriesLogger/ServiceProviderTest.php
@@ -3,24 +3,16 @@
 namespace Tests\AvtoDev\DevTools\Laravel\DatabaseQueriesLogger;
 
 use Illuminate\Database\Events\QueryExecuted;
-use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
-use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\ServiceProvider;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
 use Illuminate\Contracts\Foundation\Application;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\CreatesApplicationTrait;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\ServiceProvider;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\LaravelEventsAssertionsTrait;
+use AvtoDev\DevTools\Laravel\DatabaseQueriesLogger\QueryExecutedEventsListener;
 
 class ServiceProviderTest extends \Illuminate\Foundation\Testing\TestCase
 {
     use CreatesApplicationTrait,
         LaravelEventsAssertionsTrait;
-
-    /**
-     * @return void
-     */
-    protected function afterApplicationBootstrapped(Application $app)
-    {
-        $app->register(ServiceProvider::class);
-    }
 
     /**
      * Test event listener subscribed.
@@ -30,5 +22,13 @@ class ServiceProviderTest extends \Illuminate\Foundation\Testing\TestCase
     public function testListenerRegistered()
     {
         $this->assertEventHasListener(QueryExecuted::class, QueryExecutedEventsListener::class);
+    }
+
+    /**
+     * @return void
+     */
+    protected function afterApplicationBootstrapped(Application $app)
+    {
+        $app->register(ServiceProvider::class);
     }
 }

--- a/tests/Tests/PHPUnit/Traits/WithDatabaseQueriesLoggingTest.php
+++ b/tests/Tests/PHPUnit/Traits/WithDatabaseQueriesLoggingTest.php
@@ -34,7 +34,7 @@ class WithDatabaseQueriesLoggingTest extends AbstractLaravelTestCase
 
     public function testTraitWorking()
     {
-        /** @var \Illuminate\Database\SQLiteConnection  $connection */
+        /** @var \Illuminate\Database\SQLiteConnection $connection */
         $connection = $this->app->make('db')->connection();
 
         $connection->unprepared($sql = 'SELECT name FROM sqlite_master WHERE type = "table"');

--- a/tests/Tests/PHPUnit/Traits/WithDatabaseQueriesLoggingTest.php
+++ b/tests/Tests/PHPUnit/Traits/WithDatabaseQueriesLoggingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use Illuminate\Config\Repository as ConfigRepository;
+use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseQueriesLogging;
+
+class WithDatabaseQueriesLoggingTest extends AbstractLaravelTestCase
+{
+    use WithDatabaseQueriesLogging;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        /** @var ConfigRepository $config */
+        $config = $this->app->make('config');
+
+        $config->set('database.default', 'sqlite');
+        $config->set('database.connections.sqlite', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+
+        $this->app->make('db')->reconnect();
+
+        $this->clearLaravelLogs();
+    }
+
+    public function testTraitWorking()
+    {
+        /** @var \Illuminate\Database\SQLiteConnection  $connection */
+        $connection = $this->app->make('db')->connection();
+
+        $connection->unprepared($sql = 'SELECT name FROM sqlite_master WHERE type = "table"');
+
+        $this->assertLogFileContains($sql);
+    }
+}


### PR DESCRIPTION
### Added

- **Laravel**: Event listener for a logging database queries
- **Laravel**: Service provider that register listener for a logging database queries
- **Laravel**: Trait `WithDatabaseQueriesLogging` (use this trait in your tests classes for enabling all database queries logging)

### Changed

- Class `AbstractLaravelTestCase` now supports `WithDatabaseQueriesLogging` trait in test classes