### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **Laravel**: Trait `WithDatabaseDisconnects`
-- Method `getClosureHash()` in trait `InstancesAccessorsTrait` (requires `jeremeamia/superclosure` package installed)
+- Method `getClosureHash()` in trait `InstancesAccessorsTrait` (requires `jeremeamia/superclosure` package installed; also it requires package `nikic/php-parser` version `2.0` and above)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.4.0
+
+### Added
+
+- **Laravel**: Trait `WithDatabaseDisconnects`
+- Method `getClosureHash()` in trait `InstancesAccessorsTrait` (requires `jeremeamia/superclosure` package installed)
+
+### Changed
+
+- Class `AbstractLaravelTestCase` now supports `WithDatabaseDisconnects` trait in test classes
+
 ## v1.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Для установки данного пакета выполните в терминале следующую команду:
 
 ```shell
-$ composer require --dev avto-dev/dev-tools "^1.2"
+$ composer require --dev avto-dev/dev-tools "^1.4"
 ```
 
 > Для этого необходим установленный `composer`. Для его установки перейдите по [данной ссылке][getcomposer].
@@ -123,6 +123,7 @@ class MyBootstrap extends \AvtoDev\DevTools\Tests\Bootstrap\AbstractTestsBootstr
 `LaravelCommandsAssertionsTrait` | Методы тестирования Laravel artisan комманд
 `WithDatabaseQueriesLogging` | Подключая данный трейт в класс теста - все запросы к БД будут записываться в log-файл (класс теста должен наследоваться при этом от `AbstractLaravelTestCase`) 
 `CarbonAssertionsTrait` | Методы для тестирования `Carbon`-объектов
+`WithDatabaseDisconnects` | Подключая данный трейт в класс теста - на `tearDown` происходит отключение от всех БД ([причина](https://www.neontsunami.com/posts/too-many-connections-using-phpunit-for-testing-laravel-51))
 
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
         "jeremeamia/superclosure": "^2.4",
+        "nikic/php-parser": "^2.0 || ^3.0 || ^4.0",
         "laravel/framework": ">=5.5 <5.7.0",
         "laravel/laravel": ">=5.5 <5.7.0",
         "mockery/mockery": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
-        "jeremeamia/SuperClosure": "^2.4",
+        "jeremeamia/superclosure": "^2.4",
         "laravel/framework": ">=5.5 <5.7.0",
         "laravel/laravel": ">=5.5 <5.7.0",
         "mockery/mockery": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
-        "laravel/laravel": ">=5.5 <5.7.0",
+        "jeremeamia/SuperClosure": "^2.4",
         "laravel/framework": ">=5.5 <5.7.0",
-        "phpunit/phpunit": "^6.5 || ~7.0",
+        "laravel/laravel": ">=5.5 <5.7.0",
         "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "^6.5 || ~7.0",
         "symfony/var-dumper": "~3.3 || ^4.0"
     },
     "autoload": {
@@ -40,6 +41,7 @@
         "test-cover": "@php ./vendor/bin/phpunit"
     },
     "suggest": {
+        "jeremeamia/superclosure": "Library for closures serialization and hashing",
         "codedungeon/phpunit-result-printer": "PHPUnit Pretty Result Printer",
         "johnkary/phpunit-speedtrap": "Reports on slow-running tests in your PHPUnit test suite"
     },

--- a/src/Tests/PHPUnit/AbstractLaravelTestCase.php
+++ b/src/Tests/PHPUnit/AbstractLaravelTestCase.php
@@ -6,7 +6,6 @@ namespace AvtoDev\DevTools\Tests\PHPUnit;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase;
-use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseQueriesLogging;
 
 abstract class AbstractLaravelTestCase extends TestCase
 {
@@ -25,8 +24,12 @@ abstract class AbstractLaravelTestCase extends TestCase
     {
         $uses = parent::setUpTraits();
 
-        if (isset($uses[WithDatabaseQueriesLogging::class])) {
+        if (isset($uses[Traits\WithDatabaseQueriesLogging::class])) {
             $this->enableDatabaseQueriesLogging();
+        }
+
+        if (isset($uses[Traits\WithDatabaseDisconnects::class])) {
+            $this->enableDatabaseDisconnects();
         }
 
         return $uses;

--- a/src/Tests/PHPUnit/Traits/InstancesAccessorsTrait.php
+++ b/src/Tests/PHPUnit/Traits/InstancesAccessorsTrait.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
+use Closure;
+use Exception;
 use ReflectionClass;
 use ReflectionException;
+use SuperClosure\Serializer as ClosureSerializer;
 
 trait InstancesAccessorsTrait
 {
@@ -48,5 +51,29 @@ trait InstancesAccessorsTrait
         $property->setAccessible(true);
 
         return $property->getValue($object);
+    }
+
+    /**
+     * Calculate closure hash sum.
+     *
+     * As you know - you cannot serialize closure 'as is' for hashing. So - this is a little hack for this shit!
+     *
+     * @param Closure $closure
+     *
+     * @return string
+     *
+     * @throws Exception
+     */
+    public static function getClosureHash(Closure $closure): string
+    {
+        // @codeCoverageIgnoreStart
+        if (! class_exists(ClosureSerializer::class)) {
+            throw new Exception(sprintf('Package [%s] is required for [%s] method', 'jeremeamia/superclosure', __METHOD__));
+        }
+        // @codeCoverageIgnoreEnd
+
+        return sha1(
+            (new ClosureSerializer())->serialize($closure->bindTo(new \stdClass))
+        );
     }
 }

--- a/src/Tests/PHPUnit/Traits/InstancesAccessorsTrait.php
+++ b/src/Tests/PHPUnit/Traits/InstancesAccessorsTrait.php
@@ -60,9 +60,9 @@ trait InstancesAccessorsTrait
      *
      * @param Closure $closure
      *
-     * @return string
-     *
      * @throws Exception
+     *
+     * @return string
      */
     public static function getClosureHash(Closure $closure): string
     {

--- a/src/Tests/PHPUnit/Traits/WithDatabaseDisconnects.php
+++ b/src/Tests/PHPUnit/Traits/WithDatabaseDisconnects.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use Closure;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * @link https://www.neontsunami.com/posts/too-many-connections-using-phpunit-for-testing-laravel-51
+ */
+trait WithDatabaseDisconnects
+{
+    /**
+     * Make disconnect for all database connections.
+     *
+     * @param Application $app
+     *
+     * @return bool
+     */
+    public function disconnectFromAllDatabaseConnections(Application $app = null): bool
+    {
+        $result = false;
+
+        /** @var Application $app */
+        $app = $app instanceof Application
+            ? $app
+            : $this->app;
+
+        foreach ($app->make('db')->getConnections() as $connection) {
+            if ($connection instanceof Connection) {
+                $connection->disconnect();
+
+                if ($result !== true) {
+                    $result = true;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Disconnects closure factory.
+     *
+     * @return Closure
+     */
+    protected function databaseDisconnectsClosureFactory(): Closure
+    {
+        return function () {
+            $this->disconnectFromAllDatabaseConnections();
+        };
+    }
+
+    /**
+     * Enable disconnects from all databases before the application is destroyed for this test class.
+     *
+     * @return void
+     */
+    public function enableDatabaseDisconnects()
+    {
+        $this->beforeApplicationDestroyed($this->databaseDisconnectsClosureFactory());
+    }
+}

--- a/src/Tests/PHPUnit/Traits/WithDatabaseDisconnects.php
+++ b/src/Tests/PHPUnit/Traits/WithDatabaseDisconnects.php
@@ -43,6 +43,16 @@ trait WithDatabaseDisconnects
     }
 
     /**
+     * Enable disconnects from all databases before the application is destroyed for this test class.
+     *
+     * @return void
+     */
+    public function enableDatabaseDisconnects()
+    {
+        $this->beforeApplicationDestroyed($this->databaseDisconnectsClosureFactory());
+    }
+
+    /**
      * Disconnects closure factory.
      *
      * @return Closure
@@ -52,15 +62,5 @@ trait WithDatabaseDisconnects
         return function () {
             $this->disconnectFromAllDatabaseConnections();
         };
-    }
-
-    /**
-     * Enable disconnects from all databases before the application is destroyed for this test class.
-     *
-     * @return void
-     */
-    public function enableDatabaseDisconnects()
-    {
-        $this->beforeApplicationDestroyed($this->databaseDisconnectsClosureFactory());
     }
 }

--- a/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
@@ -47,7 +47,7 @@ class InstancesAccessorsTraitTest extends AbstractTestCase
                 };
             },
             function () {
-                return $this->resetCount();
+                $this->resetCount();
             },
         ];
 
@@ -57,6 +57,9 @@ class InstancesAccessorsTraitTest extends AbstractTestCase
             $hash = $this->getClosureHash($test_case);
 
             $this->assertGreaterThanOrEqual(8, \mb_strlen($hash));
+
+            // Second call for a closure
+            $this->assertEquals($hash, $this->getClosureHash($test_case));
         }
     }
 }

--- a/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
@@ -40,10 +40,10 @@ class InstancesAccessorsTraitTest extends AbstractTestCase
     public function testGetClosureHash()
     {
         $test_cases = [
-            function () {},
+            function () {
+            },
             function () {
                 return new class extends AbstractLaravelTestCase {
-
                 };
             },
             function () {
@@ -56,7 +56,7 @@ class InstancesAccessorsTraitTest extends AbstractTestCase
         foreach ($test_cases as $test_case) {
             $hash = $this->getClosureHash($test_case);
 
-            $this->assertGreaterThanOrEqual(8, \strlen($hash));
+            $this->assertGreaterThanOrEqual(8, \mb_strlen($hash));
         }
     }
 }

--- a/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/InstancesAccessorsTraitTest.php
@@ -4,6 +4,7 @@ namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits;
 
 use Tests\AvtoDev\DevTools\AbstractTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
+use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use AvtoDev\DevTools\Tests\PHPUnit\Traits\InstancesAccessorsTrait;
 
@@ -31,5 +32,31 @@ class InstancesAccessorsTraitTest extends AbstractTestCase
 
         $this->assertEquals('foo', $this->getProperty($instance, 'property'));
         $this->assertEquals('bar', $this->callMethod($instance, 'method'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetClosureHash()
+    {
+        $test_cases = [
+            function () {},
+            function () {
+                return new class extends AbstractLaravelTestCase {
+
+                };
+            },
+            function () {
+                return $this->resetCount();
+            },
+        ];
+
+        $this->assertNotEmpty($test_cases);
+
+        foreach ($test_cases as $test_case) {
+            $hash = $this->getClosureHash($test_case);
+
+            $this->assertGreaterThanOrEqual(8, \strlen($hash));
+        }
     }
 }

--- a/tests/Tests/PHPUnit/Traits/WithDatabaseDisconnectsTest.php
+++ b/tests/Tests/PHPUnit/Traits/WithDatabaseDisconnectsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\AvtoDev\DevTools\Tests\PHPUnit\Traits;
+
+use Illuminate\Database\Connection;
+use Illuminate\Config\Repository as ConfigRepository;
+use AvtoDev\DevTools\Tests\PHPUnit\AbstractLaravelTestCase;
+use AvtoDev\DevTools\Tests\PHPUnit\Traits\WithDatabaseDisconnects;
+
+class WithDatabaseDisconnectsTest extends AbstractLaravelTestCase
+{
+    use WithDatabaseDisconnects;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        /** @var ConfigRepository $config */
+        $config = $this->app->make('config');
+
+        $config->set('database.default', 'sqlite');
+        $config->set('database.connections.sqlite', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+
+        $this->app->make('db')->reconnect();
+    }
+
+    /**
+     * Test `disconnectFromAllDatabaseConnections()` method.
+     *
+     * @return void
+     */
+    public function testDisconnectFromAllDatabaseConnections()
+    {
+        $this->assertTrue(
+            $this->app->make('db')->connection()->unprepared(
+                $sql = 'SELECT name FROM sqlite_master WHERE type = "table"')
+        );
+
+        $this->assertTrue($this->databaseHasActiveConnections());
+        $this->assertTrue($this->disconnectFromAllDatabaseConnections($this->app));
+        $this->assertFalse($this->databaseHasActiveConnections());
+    }
+
+    /**
+     * Test `disconnectFromAllDatabaseConnections()` method without passing application instance.
+     *
+     * @return void
+     */
+    public function testDisconnectFromAllDatabaseConnectionsWithoutPassingApp()
+    {
+        $this->assertTrue($this->databaseHasActiveConnections());
+        $this->assertTrue($this->disconnectFromAllDatabaseConnections());
+        $this->assertFalse($this->databaseHasActiveConnections());
+    }
+
+    /**
+     * Test closure registration.
+     *
+     * @return void
+     */
+    public function testClosureRegistration()
+    {
+        $closure_hash = static::getClosureHash($this->databaseDisconnectsClosureFactory());
+        $found = false;
+
+        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+            if (static::getClosureHash($callback) === $closure_hash) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'Closure is not registered on application destroyed');
+    }
+
+    /**
+     * Database has an active connection?
+     *
+     * @return bool
+     */
+    protected function databaseHasActiveConnections(): bool
+    {
+        foreach ($this->app->make('db')->getConnections() as $connection) {
+            if ($connection instanceof Connection && $connection->getPdo() instanceof \PDO) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Tests/PHPUnit/Traits/WithDatabaseDisconnectsTest.php
+++ b/tests/Tests/PHPUnit/Traits/WithDatabaseDisconnectsTest.php
@@ -68,7 +68,7 @@ class WithDatabaseDisconnectsTest extends AbstractLaravelTestCase
     public function testClosureRegistration()
     {
         $closure_hash = static::getClosureHash($this->databaseDisconnectsClosureFactory());
-        $found = false;
+        $found        = false;
 
         foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
             if (static::getClosureHash($callback) === $closure_hash) {


### PR DESCRIPTION
### Added

- **Laravel**: Trait `WithDatabaseDisconnects`
- Method `getClosureHash()` in trait `InstancesAccessorsTrait` (requires `jeremeamia/superclosure` package installed)

### Changed

- Class `AbstractLaravelTestCase` now supports `WithDatabaseDisconnects` trait in test classes