### PR TITLE
v1.6.1 - Fix regex in method getVersionRegexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.6.1
+
+### Fixed
+
+- Method `getVersionRegexp` in trait `AppVersionAssertionsTrait`
+
 ## v1.6.0
 
 ### Added

--- a/src/Tests/PHPUnit/Traits/AppVersionAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/AppVersionAssertionsTrait.php
@@ -34,7 +34,7 @@ trait AppVersionAssertionsTrait
      */
     public function getVersionRegexp(): string
     {
-        return '~^##[ \\[]+[vV]?(\\d\\.\\d\\.\\d).*$~m';
+        return '~^##[ \\[]+[vV]?(\\d+\\.\\d+\\.\\d+).*$~m';
     }
 
     /**

--- a/tests/Tests/PHPUnit/Traits/AppVersionAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AppVersionAssertionsTraitTest.php
@@ -250,6 +250,49 @@ EOF;
     }
 
     /**
+     * Test assert with short changelog format.
+     *
+     * @return void
+     */
+    public function testWithLongVersionsParts()
+    {
+        $instance = new class extends \PHPUnit\Framework\TestCase {
+            use \AvtoDev\DevTools\Tests\PHPUnit\Traits\AppVersionAssertionsTrait;
+
+            public function getChangeLogFileLocation(): string
+            {
+                return '';
+            }
+
+            public function getCurrentApplicationVersion(): string
+            {
+                return '111.2.3333';
+            }
+
+            public function getChangeLogFileContent(): string
+            {
+                return <<<'EOF'
+# Changelog
+
+## v111.2.3333
+
+### Changed
+
+- Update and improvement of Polish translation.
+
+## v0.1.2
+
+### Added
+
+- New visual identity.
+EOF;
+            }
+        };
+
+        $instance->assertAppVersionAndVersionInChangeLogIsEquals();
+    }
+
+    /**
      * Test failed assertion.
      *
      * @return void


### PR DESCRIPTION
### Fixed

- Method `getVersionRegexp` in trait `AppVersionAssertionsTrait`