### PR TITLE
Added assertJsonStructure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+
+## v1.11.0
+
+### Added
+
+- `assertJsonStructure` method in `AdditionalAssertionsTrait`
+
 ## v1.10.0
 
 ### Added

--- a/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
@@ -328,16 +328,23 @@ trait AdditionalAssertionsTrait
      *
      * @param array  $structure
      * @param string $json_string
+     * @param int    $encode_options
      *
-     * @throws \InvalidArgumentException
+     * @throws AssertionFailedError
+     * @throws InvalidArgumentException
      */
-    public static function assertJsonStructure($structure, $json_string)
+    public static function assertJsonStructure($structure, $json_string, int $encode_options = 0)
     {
         static::assertIsString($json_string);
-        $testing_array = \json_decode($json_string, true);
-        if (\json_last_error()) {
+
+        $testing_array = \json_decode($json_string, true, 512, $encode_options);
+        if (\json_last_error() !== JSON_ERROR_NONE) {
             throw new \InvalidArgumentException('Passed string has not valid JSON format.');
         }
+        if (! \is_array($testing_array)) {
+            throw new \InvalidArgumentException('Passed data is not array.');
+        }
+
         static::assertArrayStructure($structure, $testing_array);
     }
 }

--- a/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
@@ -327,14 +327,14 @@ trait AdditionalAssertionsTrait
      * Assert that the JSON-encoded array has a given structure.
      *
      * @param array  $structure
-     * @param string $testing_array_json
+     * @param string $json_string
      *
      * @throws \InvalidArgumentException
      */
-    public static function assertJsonStructure($structure, $testing_array_json)
+    public static function assertJsonStructure($structure, $json_string)
     {
-        static::assertIsString($testing_array_json);
-        $testing_array = \json_decode($testing_array_json, true);
+        static::assertIsString($json_string);
+        $testing_array = \json_decode($json_string, true);
         if (\json_last_error()) {
             throw new \InvalidArgumentException('Invalid JSON given');
         }

--- a/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
@@ -336,7 +336,7 @@ trait AdditionalAssertionsTrait
         static::assertIsString($json_string);
         $testing_array = \json_decode($json_string, true);
         if (\json_last_error()) {
-            throw new \InvalidArgumentException('Invalid JSON given');
+            throw new \InvalidArgumentException('Passed string has not valid JSON format.');
         }
         static::assertArrayStructure($structure, $testing_array);
     }

--- a/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
+++ b/src/Tests/PHPUnit/Traits/AdditionalAssertionsTrait.php
@@ -322,4 +322,22 @@ trait AdditionalAssertionsTrait
             }
         }
     }
+
+    /**
+     * Assert that the JSON-encoded array has a given structure.
+     *
+     * @param array  $structure
+     * @param string $testing_array_json
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function assertJsonStructure($structure, $testing_array_json)
+    {
+        static::assertIsString($testing_array_json);
+        $testing_array = \json_decode($testing_array_json, true);
+        if (\json_last_error()) {
+            throw new \InvalidArgumentException('Invalid JSON given');
+        }
+        static::assertArrayStructure($structure, $testing_array);
+    }
 }

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -78,7 +78,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
         ]);
 
         /* @see AdditionalAssertionsTrait::assertArrayStructure */
-        $structures = $this->structuresData();
+        $structures = $this->getStructuresData();
         $this->makeAssertTest('assertArrayStructure', $structures['valid'], $structures['invalid'], $structures['testing_array']);
 
         /* @see AdditionalAssertionsTrait::assertJsonStructure */
@@ -117,7 +117,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
      *
      * @return array
      */
-    private function structuresData()
+    private function getStructuresData()
     {
         return [
             // Valid structures

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -77,8 +77,49 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
             TraitOne::class, TraitTwo::class, TraitThree::class,
         ]);
 
+        /* @see AdditionalAssertionsTrait::assertArrayStructure */
+        list($valid, $invalid, $testing_array) = $this->structuresData();
+        $this->makeAssertTest('assertArrayStructure', $valid, $invalid, $testing_array);
+
+        /* @see AdditionalAssertionsTrait::assertJsonStructure */
         $this->makeAssertTest(
-            'assertArrayStructure',
+            'assertJsonStructure',
+            $valid,
+            $invalid,
+            '{"foo":"var","bar":"var","bus":[{"alice":"var","bob":"var"}]}'
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid JSON given
+     */
+    public function testAssertJsonStructureException()
+    {
+        /* @see AdditionalAssertionsTrait::assertJsonStructure */
+        $this->makeAssertTest('assertJsonStructure', [[]], [[]], 'Invalid JSON');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed|\PHPUnit\Framework\TestCase
+     */
+    protected function classUsedTraitFactory()
+    {
+        return new class extends \PHPUnit\Framework\TestCase {
+            use \AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
+        };
+    }
+
+    /**
+     * Get array [$validStructureArr, $invalidStructureArr, $testingArray]
+     *
+     * @return array
+     */
+    private function structuresData()
+    {
+        return [
             // Valid structures
             [
                 [
@@ -122,19 +163,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
                         'bob'   => 'var',
                     ],
                 ],
-            ]
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return mixed|\PHPUnit\Framework\TestCase
-     */
-    protected function classUsedTraitFactory()
-    {
-        return new class extends \PHPUnit\Framework\TestCase {
-            use \AvtoDev\DevTools\Tests\PHPUnit\Traits\AdditionalAssertionsTrait;
-        };
+            ],
+        ];
     }
 }

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -79,7 +79,12 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
 
         /* @see AdditionalAssertionsTrait::assertArrayStructure */
         $structures = $this->getStructuresData();
-        $this->makeAssertTest('assertArrayStructure', $structures['valid'], $structures['invalid'], $structures['testing_array']);
+        $this->makeAssertTest(
+            'assertArrayStructure',
+            $structures['valid'],
+            $structures['invalid'],
+            $structures['testing_array']
+        );
 
         /* @see AdditionalAssertionsTrait::assertJsonStructure */
         $this->makeAssertTest(
@@ -90,6 +95,9 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testAssertJsonStructureException()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -78,14 +78,14 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
         ]);
 
         /* @see AdditionalAssertionsTrait::assertArrayStructure */
-        list($valid, $invalid, $testing_array) = $this->structuresData();
-        $this->makeAssertTest('assertArrayStructure', $valid, $invalid, $testing_array);
+        $structures = $this->structuresData();
+        $this->makeAssertTest('assertArrayStructure', $structures['valid'], $structures['invalid'], $structures['testing_array']);
 
         /* @see AdditionalAssertionsTrait::assertJsonStructure */
         $this->makeAssertTest(
             'assertJsonStructure',
-            $valid,
-            $invalid,
+            $structures['valid'],
+            $structures['invalid'],
             '{"foo":"var","bar":"var","bus":[{"alice":"var","bob":"var"}]}'
         );
     }
@@ -113,7 +113,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
     }
 
     /**
-     * Get array [$validStructureArr, $invalidStructureArr, $testingArray]
+     * Get array ['valid' => $validStructureArr, 'invalid' => $invalidStructureArr, 'testing_array' => $testingArray].
      *
      * @return array
      */
@@ -121,7 +121,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
     {
         return [
             // Valid structures
-            [
+            'valid'         => [
                 [
                     'foo',
                     'bar',
@@ -137,7 +137,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
                 ],
             ],
             // Invalid structures
-            [
+            'invalid'       => [
                 [
                     'xyz', // no key in first level
                 ],
@@ -154,7 +154,7 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
                 ],
             ],
             // Testing array
-            [
+            'testing_array' => [
                 'foo' => 'var',
                 'bar' => 'var',
                 'bus' => [

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -90,12 +90,10 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid JSON given
-     */
     public function testAssertJsonStructureException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passed string has not valid JSON format.');
         /* @see AdditionalAssertionsTrait::assertJsonStructure */
         $this->makeAssertTest('assertJsonStructure', [[]], [[]], 'Invalid JSON');
     }

--- a/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
+++ b/tests/Tests/PHPUnit/Traits/AdditionalAssertionsTraitTest.php
@@ -98,12 +98,23 @@ class AdditionalAssertionsTraitTest extends AbstractTraitTestCase
     /**
      * @return void
      */
-    public function testAssertJsonStructureException()
+    public function testAssertJsonStructureFormatException()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Passed string has not valid JSON format.');
         /* @see AdditionalAssertionsTrait::assertJsonStructure */
         $this->makeAssertTest('assertJsonStructure', [[]], [[]], 'Invalid JSON');
+    }
+
+    /**
+     * @return void
+     */
+    public function testAssertJsonStructureNotArrayException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passed data is not array.');
+        /* @see AdditionalAssertionsTrait::assertJsonStructure */
+        $this->makeAssertTest('assertJsonStructure', [[]], [[]], '"valid JSON string"');
     }
 
     /**


### PR DESCRIPTION
Added assertJsonStructure tests.
CHANGELOG.md minor version up.

| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes

## Description

Реализован assert подобный assertArrayStructure, который проверяет соответствие некой Json-строки определённой структуре - assertJsonStructure. assertJsonStructure получает на вход вместо массива JSON-строку которую декодирует и посылает в тот же assertArrayStructure.

## Checklist

- [ ] Вынес одинаковые тестовые данные для assertArrayStructure и assertJsonStructure в переменные.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/dev-tools/blob/master/CHANGELOG.md) file


